### PR TITLE
Fixing missing gif frame time export 

### DIFF
--- a/src/ofxGifFile.cpp
+++ b/src/ofxGifFile.cpp
@@ -31,6 +31,7 @@ void ofxGifFile::addFrame(ofPixels _px, int _left, int _top, float _duration){
     if(getNumFrames() == 0){
         accumPx = _px; // we assume 1st frame is fully drawn
         f.setFromPixels(_px , _left, _top, _duration);
+		gifDuration = _duration;
     } else {
         // add new pixels to accumPx
         int cropOriginX = _left;
@@ -71,6 +72,10 @@ int ofxGifFile::getWidth(){
 
 int ofxGifFile::getHeight(){
     return h;
+}
+
+float ofxGifFile::getDuration(){
+    return gifDuration;
 }
 
 void ofxGifFile::draw(float _x, float _y){

--- a/src/ofxGifFile.h
+++ b/src/ofxGifFile.h
@@ -27,7 +27,8 @@ class ofxGifFile {
         int getNumFrames();
         int getWidth();
         int getHeight();
-        float getDuration();    
+        float getDuration();
+		 
     
         ofxGifFrame * getFrameAt(int _index);
     // array operator overload? 
@@ -52,5 +53,5 @@ class ofxGifFile {
         bool bLoop;
         float duration;
         ofPixels accumPx;
-    
+    	float gifDuration;
 };


### PR DESCRIPTION
I noticed that the export of the duration of a frame for a gif was missing.
